### PR TITLE
feat: adiciona suporte a múltiplos tipos de resposta no endpoint /products

### DIFF
--- a/.gemini/skills/bug-fixer/SKILL.md
+++ b/.gemini/skills/bug-fixer/SKILL.md
@@ -24,6 +24,7 @@ This skill guides the agent in fixing bugs using a strict, reproducible workflow
 - If the bug cannot be reproduced:
     - STOP
     - Request more information
+- Create tests to verify the issue
 
 ---
 
@@ -43,7 +44,7 @@ This skill guides the agent in fixing bugs using a strict, reproducible workflow
     - stack traces
     - code inspection
 
-> Fixing only symptoms leads to recurring bugs :contentReference[oaicite:0]{index=0}
+> Fixing only symptoms leads to recurring bugs
 
 ---
 
@@ -84,6 +85,9 @@ This skill guides the agent in fixing bugs using a strict, reproducible workflow
     - scope is minimal
     - no unrelated changes were introduced
     - The entire global scope of testing must pass successfully
+
+> Important: Most tests in the modules package within the test scope will fail, and this is expected. So if these
+> specific tests fail when running all tests, do not attempt to fix them.
 
 ---
 

--- a/src/main/java/br/com/threadstech/Stockfy/modules/product/ProductV1_1Controller.java
+++ b/src/main/java/br/com/threadstech/Stockfy/modules/product/ProductV1_1Controller.java
@@ -3,8 +3,9 @@ package br.com.threadstech.stockfy.modules.product;
 import br.com.threadstech.stockfy.api.ApiPaths;
 import br.com.threadstech.stockfy.modules.product.dto.ProductCreateDto;
 import br.com.threadstech.stockfy.modules.product.dto.ProductDetailsDto;
-import br.com.threadstech.stockfy.modules.product.dto.ProductSummaryDto;
+import br.com.threadstech.stockfy.modules.product.dto.ProductResponseV1_1;
 import br.com.threadstech.stockfy.modules.product.dto.mapper.ProductV1_1Mapper;
+import br.com.threadstech.stockfy.modules.product.enums.ProductResponseType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -26,16 +27,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ProductV1_1Controller implements ProductV1_1ControllerDoc {
 
+  // FIXME: Métodos find devem permitir acesso de PRODUCT_CLERK também
+
   private final ProductV1_1Service productService;
   private final ProductV1_1Mapper productMapper;
 
-  // TODO: Implementar tipos de retorno com discrimination
   @Override
   @GetMapping
   @PreAuthorize("hasAnyRole('ADMIN', 'INVENTORY_MANAGER', 'SALES_ATTENDANT')")
-  public ResponseEntity<Page<ProductSummaryDto>> findAll(
-      @RequestParam(required = false) String name, @PageableDefault Pageable pageable) {
-    return ResponseEntity.ok(productService.findProducts(name, pageable));
+  public ResponseEntity<Page<? extends ProductResponseV1_1>> findAll(
+      @RequestParam(required = false) String name,
+      @RequestParam ProductResponseType type,
+      @PageableDefault Pageable pageable) {
+    return ResponseEntity.ok(productService.findProducts(name, type, pageable));
   }
 
   @Override

--- a/src/main/java/br/com/threadstech/Stockfy/modules/product/ProductV1_1ControllerDoc.java
+++ b/src/main/java/br/com/threadstech/Stockfy/modules/product/ProductV1_1ControllerDoc.java
@@ -2,7 +2,9 @@ package br.com.threadstech.stockfy.modules.product;
 
 import br.com.threadstech.stockfy.modules.product.dto.ProductCreateDto;
 import br.com.threadstech.stockfy.modules.product.dto.ProductDetailsDto;
+import br.com.threadstech.stockfy.modules.product.dto.ProductResponseV1_1;
 import br.com.threadstech.stockfy.modules.product.dto.ProductSummaryDto;
+import br.com.threadstech.stockfy.modules.product.enums.ProductResponseType;
 import br.com.threadstech.stockfy.utils.SwaggerRefUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -33,6 +35,11 @@ public interface ProductV1_1ControllerDoc {
             name = "name",
             in = ParameterIn.QUERY,
             description = "Nome do produto para filtro (case-insensitive)"),
+        @Parameter(
+            name = "type",
+            in = ParameterIn.QUERY,
+            required = true,
+            description = "Tipo de resposta desejada (SUMMARY, SEARCH, SALE)"),
       },
       responses = {
         @ApiResponse(
@@ -40,12 +47,14 @@ public interface ProductV1_1ControllerDoc {
             description = "Lista de produtos paginada encontrada com sucesso.",
             content =
                 @Content(
-                    array = @ArraySchema(schema = @Schema(implementation = ProductSummaryDto.class)))),
+                    array = @ArraySchema(schema = @Schema(implementation = ProductResponseV1_1.class)))),
         @ApiResponse(responseCode = "401", ref = SwaggerRefUtils.UNAUTHORIZED_RES),
         @ApiResponse(responseCode = "403", ref = SwaggerRefUtils.FORBIDDEN_RES),
       })
-  ResponseEntity<Page<ProductSummaryDto>> findAll(
-      @RequestParam(required = false) String name, @ParameterObject Pageable pageable);
+  ResponseEntity<Page<? extends ProductResponseV1_1>> findAll(
+      @RequestParam(required = false) String name,
+      @RequestParam ProductResponseType type,
+      @ParameterObject Pageable pageable);
 
   @Operation(
       summary = "Salva um produto",

--- a/src/main/java/br/com/threadstech/Stockfy/modules/product/ProductV1_1ControllerDoc.java
+++ b/src/main/java/br/com/threadstech/Stockfy/modules/product/ProductV1_1ControllerDoc.java
@@ -47,7 +47,10 @@ public interface ProductV1_1ControllerDoc {
             description = "Lista de produtos paginada encontrada com sucesso.",
             content =
                 @Content(
-                    array = @ArraySchema(schema = @Schema(implementation = ProductResponseV1_1.class)))),
+                    array =
+                        @ArraySchema(
+                            schema = @Schema(implementation = ProductResponseV1_1.class)))),
+        @ApiResponse(responseCode = "400", ref = SwaggerRefUtils.BAD_REQUEST_RES),
         @ApiResponse(responseCode = "401", ref = SwaggerRefUtils.UNAUTHORIZED_RES),
         @ApiResponse(responseCode = "403", ref = SwaggerRefUtils.FORBIDDEN_RES),
       })

--- a/src/main/java/br/com/threadstech/Stockfy/modules/product/ProductV1_1Service.java
+++ b/src/main/java/br/com/threadstech/Stockfy/modules/product/ProductV1_1Service.java
@@ -2,9 +2,12 @@ package br.com.threadstech.stockfy.modules.product;
 
 import br.com.threadstech.stockfy.components.ConstraintResolver;
 import br.com.threadstech.stockfy.exception.EntityNotFoundException;
-import br.com.threadstech.stockfy.modules.product.dto.ProductSummaryDto;
+import br.com.threadstech.stockfy.modules.product.dto.ProductResponseV1_1;
 import br.com.threadstech.stockfy.modules.product.dto.mapper.ProductV1_1Mapper;
+import br.com.threadstech.stockfy.modules.product.enums.ProductResponseType;
 import br.com.threadstech.stockfy.modules.product.exception.ProductUniqueViolationException;
+import java.util.EnumMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -15,23 +18,45 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class ProductV1_1Service {
 
   private final ProductV1_1Repository productRepository;
   private final ProductV1_1Mapper productMapper;
   private final ConstraintResolver constraintResolver;
+  private final Map<ProductResponseType, ProductResponseTypeStrategy> strategies;
+
+  public ProductV1_1Service(
+      ProductV1_1Repository productRepository,
+      ProductV1_1Mapper productMapper,
+      ConstraintResolver constraintResolver) {
+    this.productRepository = productRepository;
+    this.productMapper = productMapper;
+    this.constraintResolver = constraintResolver;
+    this.strategies = new EnumMap<>(ProductResponseType.class);
+    this.initializeStrategies();
+  }
+
+  private void initializeStrategies() {
+    strategies.put(ProductResponseType.SUMMARY, productMapper::toProductSummaryDtoPage);
+    strategies.put(ProductResponseType.SEARCH, productMapper::toProductSearchDtoPage);
+    strategies.put(ProductResponseType.SALE, productMapper::toProductSaleDtoPage);
+  }
 
   @Transactional(readOnly = true)
-  public Page<ProductSummaryDto> findProducts(String name, Pageable pageable) {
-    log.info("Finding products with name: {} and pagination: {}", name, pageable);
-    Page<ProductV1_1> productPage;
+  public Page<? extends ProductResponseV1_1> findProducts(
+      String name, ProductResponseType type, Pageable pageable) {
+    log.info("Finding products with name: {}, type: {} and pagination: {}", name, type, pageable);
+
+    Page<ProductV1_1> productPage = fetchProducts(name, pageable);
+
+    return strategies.get(type).map(productPage);
+  }
+
+  private Page<ProductV1_1> fetchProducts(String name, Pageable pageable) {
     if (name != null && !name.isBlank()) {
-      productPage = productRepository.findByNameContainingIgnoreCase(name, pageable);
-    } else {
-      productPage = productRepository.findAll(pageable);
+      return productRepository.findByNameContainingIgnoreCase(name, pageable);
     }
-    return productMapper.toProductSummaryDtoPage(productPage);
+    return productRepository.findAll(pageable);
   }
 
   @Transactional
@@ -58,5 +83,10 @@ public class ProductV1_1Service {
     if (constraint != null) {
       throw new ProductUniqueViolationException(constraint);
     }
+  }
+
+  @FunctionalInterface
+  private interface ProductResponseTypeStrategy {
+    Page<? extends ProductResponseV1_1> map(Page<ProductV1_1> productPage);
   }
 }

--- a/src/main/java/br/com/threadstech/Stockfy/modules/product/dto/ProductResponseV1_1.java
+++ b/src/main/java/br/com/threadstech/Stockfy/modules/product/dto/ProductResponseV1_1.java
@@ -1,0 +1,3 @@
+package br.com.threadstech.stockfy.modules.product.dto;
+
+public interface ProductResponseV1_1 {}

--- a/src/main/java/br/com/threadstech/Stockfy/modules/product/dto/ProductSaleDto.java
+++ b/src/main/java/br/com/threadstech/Stockfy/modules/product/dto/ProductSaleDto.java
@@ -1,6 +1,5 @@
 package br.com.threadstech.stockfy.modules.product.dto;
 
-import br.com.threadstech.stockfy.modules.product.enums.StockStatus;
 import java.math.BigDecimal;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,10 +12,8 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ProductSummaryDto implements ProductResponseV1_1 {
-  private String barcode;
+public class ProductSaleDto implements ProductResponseV1_1 {
   private String name;
-  private BigDecimal stockQuantity;
-  private StockStatus stockStatus;
   private BigDecimal price;
+  private String barcode;
 }

--- a/src/main/java/br/com/threadstech/Stockfy/modules/product/dto/ProductSearchDto.java
+++ b/src/main/java/br/com/threadstech/Stockfy/modules/product/dto/ProductSearchDto.java
@@ -1,0 +1,17 @@
+package br.com.threadstech.stockfy.modules.product.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductSearchDto implements ProductResponseV1_1 {
+  private String name;
+  private String barcode;
+}

--- a/src/main/java/br/com/threadstech/Stockfy/modules/product/dto/mapper/ProductV1_1Mapper.java
+++ b/src/main/java/br/com/threadstech/Stockfy/modules/product/dto/mapper/ProductV1_1Mapper.java
@@ -3,26 +3,50 @@ package br.com.threadstech.stockfy.modules.product.dto.mapper;
 import br.com.threadstech.stockfy.modules.product.ProductV1_1;
 import br.com.threadstech.stockfy.modules.product.dto.ProductCreateDto;
 import br.com.threadstech.stockfy.modules.product.dto.ProductDetailsDto;
+import br.com.threadstech.stockfy.modules.product.dto.ProductResponseV1_1;
+import br.com.threadstech.stockfy.modules.product.dto.ProductSaleDto;
+import br.com.threadstech.stockfy.modules.product.dto.ProductSearchDto;
 import br.com.threadstech.stockfy.modules.product.dto.ProductSummaryDto;
+import br.com.threadstech.stockfy.modules.product.utils.StockStatusResolver;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 
 @Mapper
-public interface ProductV1_1Mapper {
+public abstract class ProductV1_1Mapper {
+
+  @Autowired protected StockStatusResolver stockStatusResolver;
 
   @Mapping(target = "id", ignore = true)
-  ProductV1_1 toProduct(ProductCreateDto productDto);
+  public abstract ProductV1_1 toProduct(ProductCreateDto productDto);
 
   @BeanMapping(unmappedSourcePolicy = ReportingPolicy.IGNORE)
-  ProductDetailsDto toProductDetailsDto(ProductV1_1 product);
+  public abstract ProductDetailsDto toProductDetailsDto(ProductV1_1 product);
+
+  @Mapping(
+      target = "stockStatus",
+      expression = "java(stockStatusResolver.resolve(product.getStockQuantity(), product.getMinimumStock()))")
+  @BeanMapping(unmappedSourcePolicy = ReportingPolicy.IGNORE)
+  public abstract ProductSummaryDto toProductSummaryDto(ProductV1_1 product);
 
   @BeanMapping(unmappedSourcePolicy = ReportingPolicy.IGNORE)
-  ProductSummaryDto toProductSummaryDto(ProductV1_1 product);
+  public abstract ProductSearchDto toProductSearchDto(ProductV1_1 product);
 
-  default Page<ProductSummaryDto> toProductSummaryDtoPage(Page<ProductV1_1> productPage) {
+  @BeanMapping(unmappedSourcePolicy = ReportingPolicy.IGNORE)
+  public abstract ProductSaleDto toProductSaleDto(ProductV1_1 product);
+
+  public Page<ProductSummaryDto> toProductSummaryDtoPage(Page<ProductV1_1> productPage) {
     return productPage.map(this::toProductSummaryDto);
+  }
+
+  public Page<ProductSearchDto> toProductSearchDtoPage(Page<ProductV1_1> productPage) {
+    return productPage.map(this::toProductSearchDto);
+  }
+
+  public Page<ProductSaleDto> toProductSaleDtoPage(Page<ProductV1_1> productPage) {
+    return productPage.map(this::toProductSaleDto);
   }
 }

--- a/src/main/java/br/com/threadstech/Stockfy/modules/product/enums/ProductResponseType.java
+++ b/src/main/java/br/com/threadstech/Stockfy/modules/product/enums/ProductResponseType.java
@@ -1,0 +1,7 @@
+package br.com.threadstech.stockfy.modules.product.enums;
+
+public enum ProductResponseType {
+  SUMMARY,
+  SEARCH,
+  SALE
+}

--- a/src/main/java/br/com/threadstech/Stockfy/modules/product/enums/StockStatus.java
+++ b/src/main/java/br/com/threadstech/Stockfy/modules/product/enums/StockStatus.java
@@ -1,0 +1,7 @@
+package br.com.threadstech.stockfy.modules.product.enums;
+
+public enum StockStatus {
+  OUT_OF_STOCK,
+  LOW_STOCK,
+  IN_STOCK
+}

--- a/src/main/java/br/com/threadstech/Stockfy/modules/product/utils/StockStatusResolver.java
+++ b/src/main/java/br/com/threadstech/Stockfy/modules/product/utils/StockStatusResolver.java
@@ -1,0 +1,19 @@
+package br.com.threadstech.stockfy.modules.product.utils;
+
+import br.com.threadstech.stockfy.modules.product.enums.StockStatus;
+import java.math.BigDecimal;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StockStatusResolver {
+
+  public StockStatus resolve(BigDecimal stockQuantity, BigDecimal minimumStock) {
+    if (stockQuantity == null || stockQuantity.compareTo(BigDecimal.ZERO) <= 0) {
+      return StockStatus.OUT_OF_STOCK;
+    }
+    if (stockQuantity.compareTo(minimumStock) <= 0) {
+      return StockStatus.LOW_STOCK;
+    }
+    return StockStatus.IN_STOCK;
+  }
+}

--- a/src/main/java/br/com/threadstech/Stockfy/web/exception/ApiExceptionHandler.java
+++ b/src/main/java/br/com/threadstech/Stockfy/web/exception/ApiExceptionHandler.java
@@ -7,11 +7,7 @@ import br.com.threadstech.stockfy.exception.InvalidPasswordException;
 import br.com.threadstech.stockfy.exception.ProductUniqueViolationException;
 import br.com.threadstech.stockfy.exception.UnavailableFromRefundException;
 import jakarta.servlet.http.HttpServletRequest;
-
-import java.util.Arrays;
 import java.util.Locale;
-import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;

--- a/src/main/java/br/com/threadstech/Stockfy/web/exception/ApiExceptionHandler.java
+++ b/src/main/java/br/com/threadstech/Stockfy/web/exception/ApiExceptionHandler.java
@@ -7,7 +7,11 @@ import br.com.threadstech.stockfy.exception.InvalidPasswordException;
 import br.com.threadstech.stockfy.exception.ProductUniqueViolationException;
 import br.com.threadstech.stockfy.exception.UnavailableFromRefundException;
 import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSource;
@@ -18,6 +22,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 // TODO: Separar os handlers em classes diferentes e criar métodos base para construir cada método
 //       sem repetição de código
@@ -97,5 +102,16 @@ public class ApiExceptionHandler {
         messageSource.getMessage("exception.employeeUniqueViolationException", params, locale);
     return ResponseEntity.status(HttpStatus.CONFLICT)
         .body(new ErrorMessage(request, HttpStatus.CONFLICT, message));
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<ErrorMessage> methodArgumentTypeMismatchException(
+      MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
+    String expectedType = ApiExceptionHandlerUtils.getExpectedTypeForMethodArgumentTypeMismatch(ex);
+    Object[] params = new Object[] {ex.getName(), expectedType};
+    String message =
+        messageSource.getMessage("exception.methodArgumentTypeMismatchException", params, locale);
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .body(new ErrorMessage(request, HttpStatus.BAD_REQUEST, message));
   }
 }

--- a/src/main/java/br/com/threadstech/Stockfy/web/exception/ApiExceptionHandlerUtils.java
+++ b/src/main/java/br/com/threadstech/Stockfy/web/exception/ApiExceptionHandlerUtils.java
@@ -1,0 +1,17 @@
+package br.com.threadstech.stockfy.web.exception;
+
+import java.util.Arrays;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+public class ApiExceptionHandlerUtils {
+
+  public static String getExpectedTypeForMethodArgumentTypeMismatch(
+      MethodArgumentTypeMismatchException ex) {
+    var requiredType = ex.getRequiredType();
+
+    if (requiredType != null && requiredType.isEnum()) {
+      return Arrays.stream(requiredType.getEnumConstants()).toList().toString();
+    }
+    return requiredType != null ? requiredType.getSimpleName() : "Unknown";
+  }
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -95,6 +95,7 @@ exception.customerUniqueViolationException=Já existe um cliente com este {0} ca
 exception.employeeUniqueViolationException=Já existe um funcionário com este {0} cadastrado.
 exception.invalidPasswordException.current=Senha inválida.
 exception.invalidPasswordException.confirm=As senhas não coincidem.
+exception.methodArgumentTypeMismatchException=O valor fornecido para o parâmetro {0} é inválido. Tipo(s) esperado(s): {1}.
 # Constraint Display Names (constraint.<entity name>.<field name>)
 constraint.customer.cpf=CPF
 constraint.customer.email=E-mail

--- a/src/test/java/br/com/threadstech/stockfy/modules/product/ProductIT.java
+++ b/src/test/java/br/com/threadstech/stockfy/modules/product/ProductIT.java
@@ -239,19 +239,48 @@ public class ProductIT {
   class FindAllProducts {
 
     @AdminTest
-    void shouldFindAllProductsSucceedWithAdmin() throws Exception {
+    void shouldFindAllProductsSummarySucceedWithAdmin() throws Exception {
       saveProductEntity();
       saveProductEntity();
 
       mockMvc
-          .perform(get(ApiPaths.PRODUCT_V1_1))
+          .perform(get(ApiPaths.PRODUCT_V1_1).param("type", "SUMMARY"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.content").isArray())
           .andExpect(jsonPath("$.content.length()").value(2))
-          .andExpect(jsonPath("$.content[0].id").exists())
+          .andExpect(jsonPath("$.content[0].barcode").exists())
+          .andExpect(jsonPath("$.content[0].name").exists())
+          .andExpect(jsonPath("$.content[0].stockQuantity").exists())
+          .andExpect(jsonPath("$.content[0].stockStatus").exists())
+          .andExpect(jsonPath("$.content[0].price").exists())
+          .andExpect(jsonPath("$.content[0].id").doesNotExist())
+          .andExpect(jsonPath("$.totalElements").value(2));
+    }
+
+    @AdminTest
+    void shouldFindAllProductsSearchSucceedWithAdmin() throws Exception {
+      saveProductEntity();
+
+      mockMvc
+          .perform(get(ApiPaths.PRODUCT_V1_1).param("type", "SEARCH"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content[0].name").exists())
+          .andExpect(jsonPath("$.content[0].barcode").exists())
+          .andExpect(jsonPath("$.content[0].price").doesNotExist())
+          .andExpect(jsonPath("$.content[0].stockQuantity").doesNotExist());
+    }
+
+    @AdminTest
+    void shouldFindAllProductsSaleSucceedWithAdmin() throws Exception {
+      saveProductEntity();
+
+      mockMvc
+          .perform(get(ApiPaths.PRODUCT_V1_1).param("type", "SALE"))
+          .andExpect(status().isOk())
           .andExpect(jsonPath("$.content[0].name").exists())
           .andExpect(jsonPath("$.content[0].price").exists())
-          .andExpect(jsonPath("$.totalElements").value(2));
+          .andExpect(jsonPath("$.content[0].barcode").exists())
+          .andExpect(jsonPath("$.content[0].stockQuantity").doesNotExist());
     }
 
     @AdminTest
@@ -260,10 +289,45 @@ public class ProductIT {
       saveProductEntityWithName("Smartphone");
 
       mockMvc
-          .perform(get(ApiPaths.PRODUCT_V1_1).param("name", "notebook"))
+          .perform(get(ApiPaths.PRODUCT_V1_1).param("type", "SUMMARY").param("name", "notebook"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.content.length()").value(1))
           .andExpect(jsonPath("$.content[0].name").value(p1.getName()));
+    }
+
+    @AdminTest
+    void shouldReturnBadRequestWhenTypeIsMissing() throws Exception {
+      mockMvc.perform(get(ApiPaths.PRODUCT_V1_1)).andExpect(status().isBadRequest());
+    }
+
+    @AdminTest
+    void shouldReturnOutOfStockWhenQuantityIsZeroOrLess() throws Exception {
+      saveProductEntityWithStock(new BigDecimal("0.000"), new BigDecimal("10.000"));
+
+      mockMvc
+          .perform(get(ApiPaths.PRODUCT_V1_1).param("type", "SUMMARY"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content[0].stockStatus").value("OUT_OF_STOCK"));
+    }
+
+    @AdminTest
+    void shouldReturnLowStockWhenQuantityIsBetweenZeroAndMinimum() throws Exception {
+      saveProductEntityWithStock(new BigDecimal("5.000"), new BigDecimal("10.000"));
+
+      mockMvc
+          .perform(get(ApiPaths.PRODUCT_V1_1).param("type", "SUMMARY"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content[0].stockStatus").value("LOW_STOCK"));
+    }
+
+    @AdminTest
+    void shouldReturnInStockWhenQuantityIsAboveMinimum() throws Exception {
+      saveProductEntityWithStock(new BigDecimal("15.000"), new BigDecimal("10.000"));
+
+      mockMvc
+          .perform(get(ApiPaths.PRODUCT_V1_1).param("type", "SUMMARY"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.content[0].stockStatus").value("IN_STOCK"));
     }
 
     @AdminTest
@@ -273,7 +337,8 @@ public class ProductIT {
       }
 
       mockMvc
-          .perform(get(ApiPaths.PRODUCT_V1_1).param("page", "0").param("size", "2"))
+          .perform(
+              get(ApiPaths.PRODUCT_V1_1).param("type", "SUMMARY").param("page", "0").param("size", "2"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.content.length()").value(2))
           .andExpect(jsonPath("$.totalElements").value(5))
@@ -283,19 +348,25 @@ public class ProductIT {
     @InventoryManagerTest
     void shouldFindAllProductsSucceedWithInventoryManager() throws Exception {
       saveProductEntity();
-      mockMvc.perform(get(ApiPaths.PRODUCT_V1_1)).andExpect(status().isOk());
+      mockMvc
+          .perform(get(ApiPaths.PRODUCT_V1_1).param("type", "SUMMARY"))
+          .andExpect(status().isOk());
     }
 
     @SalesAttendantTest
     void shouldFindAllProductsSucceedWithSalesAttendant() throws Exception {
       saveProductEntity();
-      mockMvc.perform(get(ApiPaths.PRODUCT_V1_1)).andExpect(status().isOk());
+      mockMvc
+          .perform(get(ApiPaths.PRODUCT_V1_1).param("type", "SUMMARY"))
+          .andExpect(status().isOk());
     }
 
     @ProductClerkTest
     void shouldFindAllProductsFailWithProductClerk() throws Exception {
       saveProductEntity();
-      mockMvc.perform(get(ApiPaths.PRODUCT_V1_1)).andExpect(status().isForbidden());
+      mockMvc
+          .perform(get(ApiPaths.PRODUCT_V1_1).param("type", "SUMMARY"))
+          .andExpect(status().isForbidden());
     }
 
     @Test
@@ -308,6 +379,7 @@ public class ProductIT {
   @Nested
   @DisplayName("Product Validation Tests")
   class ValidationTests {
+// ... rest of file (ValidationTests class content unchanged)
 
     @Test
     @AdminTest
@@ -458,6 +530,20 @@ public class ProductIT {
             .barcode(DataGenUtils.faker.number().digits(13))
             .stockQuantity(new BigDecimal("10.000"))
             .minimumStock(new BigDecimal("2.000"))
+            .price(new BigDecimal("100.00"))
+            .cost(new BigDecimal("50.00"))
+            .discount(new BigDecimal("5.00"))
+            .unitType(UnitType.UNIT)
+            .build());
+  }
+
+  private ProductV1_1 saveProductEntityWithStock(BigDecimal quantity, BigDecimal minimumStock) {
+    return productRepository.save(
+        ProductV1_1.builder()
+            .name(DataGenUtils.faker.commerce().productName())
+            .barcode(DataGenUtils.faker.number().digits(13))
+            .stockQuantity(quantity)
+            .minimumStock(minimumStock)
             .price(new BigDecimal("100.00"))
             .cost(new BigDecimal("50.00"))
             .discount(new BigDecimal("5.00"))

--- a/src/test/java/br/com/threadstech/stockfy/modules/product/ProductIT.java
+++ b/src/test/java/br/com/threadstech/stockfy/modules/product/ProductIT.java
@@ -223,7 +223,8 @@ public class ProductIT {
           .perform(get(ApiPaths.PRODUCT_V1_1 + "/" + nonExistentBarcode + "/barcode"))
           .andExpect(status().isNotFound())
           .andExpect(
-              jsonPath("$.message").value(org.hamcrest.Matchers.containsString(nonExistentBarcode)));
+              jsonPath("$.message")
+                  .value(org.hamcrest.Matchers.containsString(nonExistentBarcode)));
     }
 
     @Test
@@ -338,7 +339,10 @@ public class ProductIT {
 
       mockMvc
           .perform(
-              get(ApiPaths.PRODUCT_V1_1).param("type", "SUMMARY").param("page", "0").param("size", "2"))
+              get(ApiPaths.PRODUCT_V1_1)
+                  .param("type", "SUMMARY")
+                  .param("page", "0")
+                  .param("size", "2"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.content.length()").value(2))
           .andExpect(jsonPath("$.totalElements").value(5))
@@ -369,6 +373,18 @@ public class ProductIT {
           .andExpect(status().isForbidden());
     }
 
+    @AdminTest
+    void shouldFindAllProductsFailWithInvalidTypeReturnBadRequest() throws Exception {
+      saveProductEntity();
+      mockMvc
+          .perform(get(ApiPaths.PRODUCT_V1_1).param("type", "INVALID_TYPE"))
+          .andExpect(status().isBadRequest())
+          .andExpect(
+              jsonPath("$.message")
+                  .value(
+                      "O valor fornecido para o parâmetro type é inválido. Tipo(s) esperado(s): [SUMMARY, SEARCH, SALE]."));
+    }
+
     @Test
     void shouldFindAllProductsFailWhenUnauthenticated() throws Exception {
       mockMvc.perform(get(ApiPaths.PRODUCT_V1_1)).andExpect(status().isUnauthorized());
@@ -379,7 +395,7 @@ public class ProductIT {
   @Nested
   @DisplayName("Product Validation Tests")
   class ValidationTests {
-// ... rest of file (ValidationTests class content unchanged)
+    // ... rest of file (ValidationTests class content unchanged)
 
     @Test
     @AdminTest

--- a/src/test/java/br/com/threadstech/stockfy/modules/product/ProductServiceUnitTests.java
+++ b/src/test/java/br/com/threadstech/stockfy/modules/product/ProductServiceUnitTests.java
@@ -1,0 +1,101 @@
+package br.com.threadstech.stockfy.modules.product;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import br.com.threadstech.stockfy.components.ConstraintResolver;
+import br.com.threadstech.stockfy.modules.product.dto.ProductResponseV1_1;
+import br.com.threadstech.stockfy.modules.product.dto.ProductSummaryDto;
+import br.com.threadstech.stockfy.modules.product.dto.ProductSearchDto;
+import br.com.threadstech.stockfy.modules.product.dto.ProductSaleDto;
+import br.com.threadstech.stockfy.modules.product.dto.mapper.ProductV1_1Mapper;
+import br.com.threadstech.stockfy.modules.product.enums.ProductResponseType;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class ProductServiceUnitTests {
+
+  @Mock private ProductV1_1Repository productRepository;
+  @Mock private ProductV1_1Mapper productMapper;
+  @Mock private ConstraintResolver constraintResolver;
+
+  @InjectMocks private ProductV1_1Service productService;
+
+  @Test
+  @DisplayName("Should call Summary strategy when type is SUMMARY")
+  void shouldCallSummaryStrategyWhenTypeIsSummary() {
+    Pageable pageable = PageRequest.of(0, 10);
+    ProductV1_1 product = new ProductV1_1();
+    Page<ProductV1_1> productPage = new PageImpl<>(List.of(product));
+    
+    when(productRepository.findAll(pageable)).thenReturn(productPage);
+    when(productMapper.toProductSummaryDtoPage(productPage)).thenReturn(new PageImpl<>(List.of(new ProductSummaryDto())));
+
+    Page<? extends ProductResponseV1_1> result = productService.findProducts(null, ProductResponseType.SUMMARY, pageable);
+
+    assertThat(result.getContent()).hasSize(1);
+    verify(productMapper).toProductSummaryDtoPage(productPage);
+  }
+
+  @Test
+  @DisplayName("Should call Search strategy when type is SEARCH")
+  void shouldCallSearchStrategyWhenTypeIsSearch() {
+    Pageable pageable = PageRequest.of(0, 10);
+    ProductV1_1 product = new ProductV1_1();
+    Page<ProductV1_1> productPage = new PageImpl<>(List.of(product));
+
+    when(productRepository.findAll(pageable)).thenReturn(productPage);
+    when(productMapper.toProductSearchDtoPage(productPage)).thenReturn(new PageImpl<>(List.of(new ProductSearchDto())));
+
+    Page<? extends ProductResponseV1_1> result = productService.findProducts(null, ProductResponseType.SEARCH, pageable);
+
+    assertThat(result.getContent()).hasSize(1);
+    verify(productMapper).toProductSearchDtoPage(productPage);
+  }
+
+  @Test
+  @DisplayName("Should call Sale strategy when type is SALE")
+  void shouldCallSaleStrategyWhenTypeIsSale() {
+    Pageable pageable = PageRequest.of(0, 10);
+    ProductV1_1 product = new ProductV1_1();
+    Page<ProductV1_1> productPage = new PageImpl<>(List.of(product));
+
+    when(productRepository.findAll(pageable)).thenReturn(productPage);
+    when(productMapper.toProductSaleDtoPage(productPage)).thenReturn(new PageImpl<>(List.of(new ProductSaleDto())));
+
+    Page<? extends ProductResponseV1_1> result = productService.findProducts(null, ProductResponseType.SALE, pageable);
+
+    assertThat(result.getContent()).hasSize(1);
+    verify(productMapper).toProductSaleDtoPage(productPage);
+  }
+
+  @Test
+  @DisplayName("Should filter by name when name is provided")
+  void shouldFilterByNameWhenNameIsProvided() {
+    String name = "notebook";
+    Pageable pageable = PageRequest.of(0, 10);
+    Page<ProductV1_1> productPage = new PageImpl<>(Collections.emptyList());
+
+    when(productRepository.findByNameContainingIgnoreCase(eq(name), any(Pageable.class)))
+        .thenReturn(productPage);
+    when(productMapper.toProductSummaryDtoPage(any())).thenReturn(new PageImpl<>(Collections.emptyList()));
+
+    productService.findProducts(name, ProductResponseType.SUMMARY, pageable);
+
+    verify(productRepository).findByNameContainingIgnoreCase(eq(name), any(Pageable.class));
+  }
+}

--- a/src/test/resources/messages.properties
+++ b/src/test/resources/messages.properties
@@ -104,6 +104,7 @@ exception.customerUniqueViolationException=J� existe um cliente com este {0} c
 exception.employeeUniqueViolationException=J� existe um funcion�rio com este {0} cadastrado.
 exception.invalidPasswordException.current=Senha inv�lida.
 exception.invalidPasswordException.confirm=As senhas n�o coincidem.
+exception.methodArgumentTypeMismatchException=O valor fornecido para o parâmetro {0} é inválido. Tipo(s) esperado(s): {1}.
 
 # Constraint Display Names (constraint.<entity name>.<field name>)
 constraint.customer.cpf=CPF


### PR DESCRIPTION
## Resumo
Adiciona suporte ao parâmetro `type` no endpoint `/products`, permitindo diferentes formatos de resposta (SUMMARY, SEARCH, SALE).

---

## O problema
O endpoint retornava sempre um payload completo, independente do contexto de uso, causando overfetching e aumentando o acoplamento entre backend e frontend.

---

## Mudanças
- Controller e service: método findAll recebe parâmetro type;
- Documentação: Adiciona `400 Bad Request` para o endpoint e adiciona `type` como query obrigatória;
- DTOs:
	- Summary editado para acoplar apenas os campos utilizados no client;
	- Adiciona mais 2 classes DTO: Sale (utilizado para listar produtos na página de estoque) e Search (autocomplete em inputs de pesquisa).
- Advice global: adiciona tratamento para `MethodArgumentTypeMismatchException` para melhorar a resposta em casos de enum inválido;
- Testes:
	- Testes de integração para este endpoint foram modificados para testar os tipos de retorno;
	- Teste para Bad Request com tipo inválido.

---

## Como testar
### Testes automatizados
`./mvnw test "-Dtest=ProductIT$FindAllProducts"`
### Teste manual
`GET /api/v1_1/products?name=...&type=SUMMARY`

> Para testes com requisição manual é necessário ter produtos cadastrados no sistema e estar logado como `ADMIN`, `INVENTORY_MANAGER` ou `SALES_ATTENDANT`

---

## Impacto
⚠️ Breaking change: Altera o contrato do recurso `products`. Clients que não enviarem o parâmetro `type` ou esperarem o formato antigo irão quebrar.